### PR TITLE
Fix Item and inferno handling

### DIFF
--- a/Views/Tabs/InfernoUnlockTableView.axaml.cs
+++ b/Views/Tabs/InfernoUnlockTableView.axaml.cs
@@ -109,6 +109,8 @@ public partial class InfernoUnlockTableView : TableTab
     
     protected override void UpdateContent(bool ignoreChange)
     {
+        if (asset == null) return;
+       
         if (explorerView?.SelectedItem == null)
         {
             ContentGroup.IsVisible = false;
@@ -194,7 +196,7 @@ public partial class InfernoUnlockTableView : TableTab
                     break;
                 }
                 
-                case "MusicId":
+                case "TextBoxMusicId":
                 { 
                     IntPropertyData intPropertyData = (IntPropertyData)data.Value[0];
                     int oldValue = intPropertyData.Value;
@@ -214,7 +216,7 @@ public partial class InfernoUnlockTableView : TableTab
                     break;
                 }
                 
-                case "RequiredInfernoOpenWaccaPoint":
+                case "TextBoxRequiredInfernoOpenWaccaPoint":
                 { 
                     IntPropertyData intPropertyData = (IntPropertyData)data.Value[2];
                     int oldValue = intPropertyData.Value;

--- a/Views/Tabs/ItemUnlockTableView.axaml.cs
+++ b/Views/Tabs/ItemUnlockTableView.axaml.cs
@@ -172,7 +172,7 @@ public partial class ItemUnlockTableView : TableTab
                     
                     try
                     {
-                        newValue = Convert.ToInt16(textBox.Text);
+                        newValue = Convert.ToInt32(textBox.Text);
                     }
                     catch (FormatException)
                     {


### PR DESCRIPTION
Fixes musicId and InfernoOpenPoints not being detected as changes and therefore not saving in InfernoUnlockTable
Fixes itemId being treated as a 16-bit intiger when converting from a string to int in ItemUnlockTable